### PR TITLE
Add IPv6 support, ignore trailing dot in IP abuse

### DIFF
--- a/abuse_finder/ip.py
+++ b/abuse_finder/ip.py
@@ -6,6 +6,10 @@ from operator import itemgetter
 from ipaddress import ip_network, ip_address
 import re
 
+abuse_terms = [
+    'abuse',
+    'OrgNOCEmail',
+]
 
 def _get_abuse_emails(raw_whois):
     score = 0
@@ -14,7 +18,7 @@ def _get_abuse_emails(raw_whois):
     for line in raw_whois.splitlines():
         email_addresses = re.findall(r'[\w\.+-]+@[\w-]+(?:\.[\w-]+)+', line)
         if email_addresses:
-            abuse_references = line.count('abuse')
+            abuse_references = sum(line.count(term) for term in abuse_terms)
 
             if abuse_references == score:
                 email_candidates = set(list(email_candidates) + email_addresses)

--- a/abuse_finder/ip.py
+++ b/abuse_finder/ip.py
@@ -3,7 +3,7 @@ from builtins import str
 
 from ipwhois import IPWhois
 from operator import itemgetter
-from ipaddress import IPv4Network, IPv4Address
+from ipaddress import ip_network, ip_address
 import re
 
 
@@ -25,27 +25,27 @@ def _get_abuse_emails(raw_whois):
     return list(email_candidates)
 
 
-def _get_names(ip_address, parsed_whois):
-    ip_address = IPv4Address(str(ip_address))
+def _get_names(address, parsed_whois):
+    address = ip_address(str(address))
     names = []
 
     for network in parsed_whois['nets']:
         for cidr in network['cidr'].split(','):
-            cidr = IPv4Network(cidr.strip())
-            if ip_address in cidr and network['description']:
+            cidr = ip_network(cidr.strip())
+            if address in cidr and network['description']:
                 names.append([cidr.prefixlen, network['description'].splitlines()[0]])
                 break
 
     return [n[1] for n in sorted(names, key=itemgetter(0), reverse=True)]
 
 
-def ip_abuse(ip_address):
-    obj = IPWhois(ip_address)
+def ip_abuse(address):
+    obj = IPWhois(address)
     results = obj.lookup_whois(inc_raw=True)
 
     return {
-        "value": ip_address,
-        "names": _get_names(ip_address, results),
+        "value": address,
+        "names": _get_names(address, results),
         "abuse": _get_abuse_emails(results['raw']),
         "raw": results['raw']
     }

--- a/abuse_finder/ip.py
+++ b/abuse_finder/ip.py
@@ -8,14 +8,14 @@ import re
 
 abuse_terms = [
     'abuse',
-    'OrgNOCEmail',
+    'orgnocemail',
 ]
 
 def _get_abuse_emails(raw_whois):
     score = 0
     email_candidates = set()
 
-    for line in raw_whois.splitlines():
+    for line in (line.lower() for line in raw_whois.splitlines()):
         email_addresses = re.findall(r'[\w\.+-]+@[\w-]+(?:\.[\w-]+)+', line)
         if email_addresses:
             abuse_references = sum(line.count(term) for term in abuse_terms)

--- a/abuse_finder/ip.py
+++ b/abuse_finder/ip.py
@@ -12,7 +12,7 @@ def _get_abuse_emails(raw_whois):
     email_candidates = set()
 
     for line in raw_whois.splitlines():
-        email_addresses = re.findall(r'[\w\.+-]+@[\w\.-]+', line)
+        email_addresses = re.findall(r'[\w\.+-]+@[\w-]+(?:\.[\w-]+)+', line)
         if email_addresses:
             abuse_references = line.count('abuse')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ipwhois
+git+https://github.com/monoidic/ipwhois.git
 ipaddress
 pythonwhois-alt
 tldextract

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup
 
 setup(name='abuse_finder',
-      version='0.2',
+      version='0.3',
       description='Look for abuse contacts for IP, domain names, email addresses and URLs.',
       url='https://github.com/certsocietegenerale/abuse_finder',
       author='CERT Société Générale',


### PR DESCRIPTION
This PR will allow abuse_finder to work with IPv6 addresses by using the IP version agnostic ip_network and ip_address functions from the `ipaddress` library. I consider this enough to bump the minor version as well.